### PR TITLE
Allows to disable stretching view to more than set height.

### DIFF
--- a/Classes/CSStickyHeaderFlowLayout.h
+++ b/Classes/CSStickyHeaderFlowLayout.h
@@ -27,5 +27,6 @@ extern NSString *const CSStickyHeaderParallaxHeader;
 @property (nonatomic) CGSize parallaxHeaderMinimumReferenceSize;
 @property (nonatomic) BOOL parallaxHeaderAlwaysOnTop;
 @property (nonatomic) BOOL disableStickyHeaders;
+@property (nonatomic) BOOL disableStretching;
 
 @end

--- a/Classes/CSStickyHeaderFlowLayout.m
+++ b/Classes/CSStickyHeaderFlowLayout.m
@@ -276,7 +276,7 @@ static const NSInteger kHeaderZIndex = 1024;
         frame.origin.x,
         y,
         frame.size.width,
-        height,
+        self.disableStretching && height > maxHeight ? maxHeight : height,
     };
     
 }


### PR DESCRIPTION
For me header was always stretching to more than set size which was not desired behaviour. So I added option to disable this.

Thank you for possible merge.