### PR TITLE
added detachTopLayout

### DIFF
--- a/Classes/CSStickyHeaderFlowLayout.h
+++ b/Classes/CSStickyHeaderFlowLayout.h
@@ -28,5 +28,5 @@ extern NSString *const CSStickyHeaderParallaxHeader;
 @property (nonatomic) BOOL parallaxHeaderAlwaysOnTop;
 @property (nonatomic) BOOL disableStickyHeaders;
 @property (nonatomic) BOOL disableStretching;
-
+@property (nonatomic) BOOL detachTopLayout;
 @end

--- a/Classes/CSStickyHeaderFlowLayout.m
+++ b/Classes/CSStickyHeaderFlowLayout.m
@@ -274,7 +274,7 @@ static const NSInteger kHeaderZIndex = 1024;
 
     currentAttribute.frame = (CGRect){
         frame.origin.x,
-        y,
+        self.detachTopLayout ? frame.origin.y : y,
         frame.size.width,
         self.disableStretching && height > maxHeight ? maxHeight : height,
     };


### PR DESCRIPTION
Set the detachTopLayout true then parallaxHeader will detach from
TopLayout. If The parrallaxHeader’s height is fixed then detach from TopLayout
option is good interaction like an original UICollectionView Controller.

[detachTopLayout is True]
![test](https://cloud.githubusercontent.com/assets/12643700/18605512/d8aa0c06-7cce-11e6-89fe-45beef6f1833.gif)

[detachTopLayout if false : default]
![question1](https://cloud.githubusercontent.com/assets/12643700/18605525/f19f9a00-7cce-11e6-8efe-618f99ed0e87.gif)

