### PR TITLE
Hotfix/fix ios10 bug

### DIFF
--- a/Classes/CSStickyHeaderFlowLayout.m
+++ b/Classes/CSStickyHeaderFlowLayout.m
@@ -104,7 +104,7 @@ static const NSInteger kHeaderZIndex = 1024;
                 UICollectionViewLayoutAttributes *currentAttribute = [lastCells objectForKey:@(indexPath.section)];
                 
                 // Get the bottom most cell of that section
-                if ( ! currentAttribute || indexPath.row > currentAttribute.indexPath.row) {
+                if ( ! currentAttribute || (indexPath.row > currentAttribute.indexPath.row && indexPath.section == currentAttribute.indexPath.section)) {
                     [lastCells setObject:obj forKey:@(indexPath.section)];
                 }
                 

--- a/Classes/CSStickyHeaderFlowLayout.m
+++ b/Classes/CSStickyHeaderFlowLayout.m
@@ -154,7 +154,7 @@ static const NSInteger kHeaderZIndex = 1024;
                 
                 UICollectionViewLayoutAttributes *header = headers[indexPathKey];
                 // CollectionView automatically removes headers not in bounds
-                if ( ! header) {
+                if ( ! header && visibleParallexHeader) {
                     header = [self layoutAttributesForSupplementaryViewOfKind:UICollectionElementKindSectionHeader
                                                                   atIndexPath:[NSIndexPath indexPathForItem:0 inSection:indexPath.section]];
                     


### PR DESCRIPTION
In iOS 10, UICollectionView & UITableView has the mechanism to prefet…
…ch cell, thus, there will be some header will not visible in screen and it can not be initialise by calling "layoutAttributesForSupplementaryViewOfKind".

In here, add a check to make sure header is visible to prevent assertion failure.

- https://developer.apple.com/videos/play/wwdc2016/219/